### PR TITLE
Fix goroutine leak and use fan-out to publish status to consumers

### DIFF
--- a/ganesha/admin.go
+++ b/ganesha/admin.go
@@ -2,6 +2,7 @@ package ganesha
 
 import (
 	"context"
+	"sync"
 
 	"github.com/godbus/dbus"
 )
@@ -9,6 +10,15 @@ import (
 // AdminMgr is a handle to Ganesha's management interface.
 type AdminMgr struct {
 	conn *dbus.Conn
+
+	// statusCh receives status updates from DBus.
+	statusCh chan *dbus.Signal
+
+	// statusWatchers holds the channels of all active status watchers.  It is
+	// keyed on the channel so that it can be easily removed. It is protected by
+	// mu.
+	statusWatchers map[chan bool]chan error
+	mu             *sync.RWMutex
 }
 
 // NewAdminMgr creates a new AdminMgr for interacting with Ganesha's management
@@ -22,34 +32,74 @@ func NewAdminMgr() (*AdminMgr, error) {
 		return nil, err
 	}
 	return &AdminMgr{
-		conn: conn,
+		conn:           conn,
+		statusCh:       make(chan *dbus.Signal),
+		statusWatchers: make(map[chan bool]chan error),
+		mu:             &sync.RWMutex{},
 	}, nil
 }
 
-// StreamStatus streams the NFS server's status to the out channel.
+// AddStatusWatcher registers a status update subscriber channel.
+func (mgr *AdminMgr) AddStatusWatcher(ctx context.Context, statusCh chan bool, errCh chan error) {
+	mgr.mu.Lock()
+	mgr.statusWatchers[statusCh] = errCh
+	mgr.mu.Unlock()
+}
+
+// RemoveStatusWatcher deregisters a status update subscriber channel.
+func (mgr *AdminMgr) RemoveStatusWatcher(ctx context.Context, ch chan bool) {
+	mgr.mu.Lock()
+	if _, ok := mgr.statusWatchers[ch]; ok {
+		delete(mgr.statusWatchers, ch)
+	}
+	mgr.mu.Unlock()
+}
+
+// MonitorStatus listens for status updates and publishes to all status
+// watchers.
 //
-// The status is received by watching for the server's heartbeat messages that
-// are published on DBus and converting to bools.
+// The status is received by matching the server's heartbeat signal messages
+// that are published on DBus and converting to bools.
 //
 // Ganesha does not sent heartbeats when the server is not ready, so in practice
 // only "alive/true" messages will be sent, and/or an error returned when the
 // context has expired or been cancelled.
-func (mgr *AdminMgr) StreamStatus(ctx context.Context, out chan bool) error {
+func (mgr *AdminMgr) MonitorStatus(ctx context.Context) error {
 
-	// Create DBus watcher for nfsd heartbeats.
+	// Match events with this signature.
 	match := "type='signal',path='/org/ganesha/nfsd/heartbeat',interface='org.ganesha.nfsd.admin',member='heartbeat'"
+
+	// Create DBus signal matcher for nfsd heartbeats.
 	mgr.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
 
-	in := make(chan *dbus.Signal)
-	mgr.conn.Signal(in)
+	// Send status signals to statusCh
+	mgr.conn.Signal(mgr.statusCh)
 
 	for {
 		select {
 		case <-ctx.Done():
+
+			// Unregister DBus signal matcher.
 			mgr.conn.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match)
+
+			// Send error to all watchers.
+			mgr.mu.RLock()
+			for _, watcherErrCh := range mgr.statusWatchers {
+				watcherErrCh <- ctx.Err()
+			}
+			mgr.mu.RUnlock()
+
 			return ctx.Err()
-		case hb := <-in:
-			out <- hb.Body[0].(bool)
+		case hb := <-mgr.statusCh:
+
+			status := hb.Body[0].(bool)
+
+			// Send status to all watchers.
+			mgr.mu.RLock()
+			for watcherStatusCh := range mgr.statusWatchers {
+				watcherStatusCh <- status
+			}
+			mgr.mu.RUnlock()
 		}
 	}
 


### PR DESCRIPTION
The status endpoint was leaking goroutines causing memory use to rise.

As part of the fix, rather than create a DBus event watcher for every health request, a single event watcher is used that publishes to any subscribers that have registered.  This saves the DBus overhead of registering & unregistering.

Stress testing was done using https://github.com/tsenart/vegeta
```
$ echo "GET http://localhost:32795/healthz" | vegeta attack -duration=300s > results.bin
$ cat results.bin | vegeta report -type="hist[0,200ms,400ms,600ms,800ms,1000ms]"
Bucket           #     %       Histogram
[0s,     200ms]  2963  19.75%  ##############
[200ms,  400ms]  2990  19.93%  ##############
[400ms,  600ms]  2993  19.95%  ##############
[600ms,  800ms]  2997  19.98%  ##############
[800ms,  1s]     3002  20.01%  ###############
[1s,     +Inf]   55    0.37%   
```
During the test, pprof shows:
```
Count | Profile
-- | --
12 | allocs
0 | block
0 | cmdline
83 | goroutine
12 | heap
0 | mutex
0 | profile
23 | threadcreate
0 | trace
```
and after:
```
Count | Profile
-- | --
26 | allocs
0 | block
0 | cmdline
9 | goroutine
26 | heap
0 | mutex
0 | profile
24 | threadcreate
0 | trace
```
On a fresh start with no hits on the /healthz endpoint there were also 9 goroutines in use.
