### PR TITLE
Add metadata and bump go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,25 @@
-FROM golang:1.12.7 AS build
+FROM golang:1.13.5 AS build
+
 WORKDIR /go/src/github.com/storageos/nfs/
 COPY . /go/src/github.com/storageos/nfs/
 RUN make build
 
 FROM storageos/nfs-base:20190903-0018
+LABEL name="StorageOS Shared File" \
+    maintainer="support@storageos.com" \
+    vendor="StorageOS" \
+    version="1.0.1" \
+    release="1" \
+    distribution-scope="public" \
+    architecture="x86_64" \
+    url="https://docs.storageos.com" \
+    io.k8s.description="The StorageOS Shared File container is used by the Cluster Operator to provide ReadWriteMany (RWX) volumes." \
+    io.k8s.display-name="StorageOS Shared File" \
+    io.openshift.tags="" \
+    summary="Highly-available persistent block and shared file storage for containerized applications." \
+    description="StorageOS transforms commodity server or cloud based disk capacity into enterprise-class storage to run persistent workloads such as databases in containers. Provides high availability, low latency persistent block storage. No other hardware or software is required."
 
-LABEL maintainer="support@storageos.com"
-
+COPY --from=build /go/src/github.com/storageos/nfs/LICENSE /licenses/
 COPY --from=build /go/src/github.com/storageos/nfs/build/_output/bin/nfs /nfs
 
 # Use for testing only.  Exports /export

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,8 @@ run:
 		-e NAMESPACE=default \
 		-e DISABLE_METRICS=false \
 		$(IMAGE)
+
+# Prepare the repo for a new release. Run:
+#   NEW_VERSION=<version> make release
+release:
+	sed -i -e "s/version=.*/version=\"$(NEW_VERSION)\" \\\/g" Dockerfile

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ The image uses `storageos/nfs-base` as the base image, which in turn is
 built on a registered RHEL8 server, it is built on internal StorageOS
 infrastructure.
 
+## Release
+
+The version must be set in the `Dockerfile`.  To set it, run:
+
+```console
+NEW_VERSION=<version> make release
+```
+
 ## Run it on host
 
 Build the init container with `make image` and run it on the host with `make


### PR DESCRIPTION
Adds metadata needed for Red hat certification. Once merged, will configure in Red hat build service.

Also bumps go version to 1.13.5 to match Operator.

Leaving metadata tags empty so it doesn't show up in searches.